### PR TITLE
Change model.evaluation() to model.eval(); Signed-off-by: Robert Engelmann rengelma@uni-potsdam.de

### DIFF
--- a/python/pytorch_benchmarks/benchmarks.py
+++ b/python/pytorch_benchmarks/benchmarks.py
@@ -158,7 +158,7 @@ def benchmark_inference(model, opts):
     if opts['dtype'] == 'float16':
         data = data.half()
         model = model.half()
-    model.evaluate()
+    model.eval()
     # Do warmup round
     for i in range(opts['num_warmup_batches']):
         model(data)


### PR DESCRIPTION
I think there was a typo here, since model.evaluation() does not exist, however it works fine with model.eval(), which corresponds to model.train().
Signed-off-by: Robert Engelmann rengelma@uni-potsdam.de