### PR TITLE
fix: numpy deprecated aliases

### DIFF
--- a/python/dlbs/data/imagenet/tensorflow_build_imagenet_data.py
+++ b/python/dlbs/data/imagenet/tensorflow_build_imagenet_data.py
@@ -430,7 +430,7 @@ def _process_image_files(name, filenames, synsets, labels, humans,
   assert len(filenames) == len(bboxes)
 
   # Break all images into batches with a [ranges[i][0], ranges[i][1]].
-  spacing = np.linspace(0, len(filenames), FLAGS.num_threads + 1).astype(np.int)
+  spacing = np.linspace(0, len(filenames), FLAGS.num_threads + 1).astype(np.int_)
   ranges = []
   threads = []
   for i in range(len(spacing) - 1):

--- a/python/pytorch_benchmarks/dataset_factory.py
+++ b/python/pytorch_benchmarks/dataset_factory.py
@@ -173,7 +173,7 @@ class SyntheticDataLoader(object):
         data_shape = (opts['batch_size'],) + input_shape
         self.data = torch.randn(data_shape)
         self.labels = torch.from_numpy(
-            np.random.randint(0, num_classes, opts['batch_size']).astype(np.long)
+            np.random.randint(0, num_classes, opts['batch_size']).astype(np.int_)
         )
         self.prefetchable = True
         if opts['device'] == 'gpu':


### PR DESCRIPTION
### replace old numpy aliases with the new ones.
code currently breaks with the latest numpy release.
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations